### PR TITLE
remove service alias

### DIFF
--- a/nfc2klipper.service
+++ b/nfc2klipper.service
@@ -7,9 +7,7 @@ After=moonraker.service
 Wants=udev.target
 
 [Install]
-Alias=nfc2klipy
 WantedBy=multi-user.target
-
 
 [Service]
 Type=simple


### PR DESCRIPTION
The alias throws the following error:

```console
thijs@bar:~/nfc2klipper $ sudo systemctl enable nfc2klipper
Failed to enable unit: Cannot alias nfc2klipper.service as nfc2klipy.
```

is this alias used somewhere?