### PR TITLE
Added filament type to Web template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -62,7 +62,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
             class="btn btn-outline-primary btn-sm"
             onclick="x({{spool['id']}}, {{spool['filament']['id']}})"
             >Write</button>
-    {{spool['id']}}: {{spool['filament']['vendor']['name']}} - {{spool['filament']['name']}}
+    {{spool['id']}}: {{spool['filament']['vendor']['name']}} - {{spool['filament']['material']}} - {{spool['filament']['name']}}
   </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
I don't have the filament type in the name, so if I add a bunch of different filament with the same colour at the same time, I can't tell which one is the PLA or which one is the PETG.