### PR TITLE
Add cfg "always-send" in "moonraker" section.

### DIFF
--- a/nfc2klipper.cfg
+++ b/nfc2klipper.cfg
@@ -25,3 +25,7 @@ moonraker-url = "http://mainsailos.local"
 
 # If true, clears the spool & filament info if no tag can be read.
 clear-spool = false
+
+# If true, the SET_ACTIVE_* macros are called every time the tag is read.
+# If false, the SET_ACTIVE_* macros are not called when the same tag is read again.
+always-send = false

--- a/nfc2klipper.py
+++ b/nfc2klipper.py
@@ -61,6 +61,17 @@ nfc_handler = NfcHandler(args["nfc"]["nfc-device"])
 app = Flask(__name__)
 
 
+def should_always_send():
+    """Should SET_ACTIVE_* macros always be called when tag is read,
+    or only when different?"""
+    always_send = args["moonraker"].get("always-send")
+
+    if always_send is None:
+        return False
+
+    return always_send
+
+
 def set_spool_and_filament(spool: int, filament: int):
     """Calls moonraker with the current spool & filament"""
 
@@ -68,7 +79,7 @@ def set_spool_and_filament(spool: int, filament: int):
         set_spool_and_filament.old_spool = None
         set_spool_and_filament.old_filament = None
 
-    if (
+    if not should_always_send() and (
         set_spool_and_filament.old_spool == spool
         and set_spool_and_filament.old_filament == filament
     ):


### PR DESCRIPTION
When true, the SET_ACTIVE_* macros are always called. When missing, or false, avoid calling them after reading the same spool & filament id again.